### PR TITLE
Updates theme to fork of original and changes color for 2024

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/terminal"]
 	path = themes/terminal
-	url = https://github.com/panr/hugo-theme-terminal.git
+	url = https://github.com/hacktoberfesthowto/hugo-theme-terminal.git

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ paginate = 5
   contentTypeName = "posts"
 
   # ["orange", "blue", "red", "green", "pink"]
-  themeColor = "pink"
+  themeColor = "green"
 
   # if you set this to 0, only submenu trigger will be visible
   showMenuItems = 2


### PR DESCRIPTION
## Type of Contribution

Check the item(s) that applies.

<!-- For example:
- [x] HOWTO Content update -->

- [ ] :zap: HOWTO Content update
- [x] 📃 Hugo static site update
- [ ] :icecream: README or site documentation update

### Is this pull request related to an existing issue? If so, which one is it?

- [x] :white_check_mark: Yes! - Issue number: #45 
- [ ] :x: No, sorry.

## Description

<!-- Describe the changes that you've made in this PR. For example, "This PR adds a new section to the blog" or "This PR updates one of the existing pages with new or updated information." -->
I've updated the site color to green to match the vibe of this year, and I've updated the hugo theme to refer to the organization's fork of the theme because the original theme has been archived.
