### PR TITLE
Fixed broken links in `_index.md`

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -17,5 +17,5 @@ This repo contains tips for two sets of folks:
 * Hacktoberfest participants that want to use the allure of a comfy free t-shirt to try out contributing to open source.
 
 
-# [HOWTO - Contributors](/howto-contributors.md)
-# [HOWTO - Maintainers](/howto-maintainers.md)
+# [HOWTO - Contributors](https://github.com/hacktoberfesthowto/howto-blog/blob/main/content/howto-contributors.md)
+# [HOWTO - Maintainers](https://github.com/hacktoberfesthowto/howto-blog/blob/main/content/howto-maintainers.md)

--- a/content/_index.md
+++ b/content/_index.md
@@ -17,5 +17,5 @@ This repo contains tips for two sets of folks:
 * Hacktoberfest participants that want to use the allure of a comfy free t-shirt to try out contributing to open source.
 
 
-# [HOWTO - Contributors](/howto-contributors)
-# [HOWTO - Maintainers](/howto-maintainers)
+# [HOWTO - Contributors](/howto-contributors.md)
+# [HOWTO - Maintainers](/howto-maintainers.md)


### PR DESCRIPTION
## Type of Contribution

Check the item(s) that applies.

<!-- For example:
- [x] HOWTO Content update -->

- [ ] :zap: HOWTO Content update
- [ ] 📃 Hugo static site update
- [x] :icecream: README or site documentation update

### Is this pull request related to an existing issue? If so, which one is it?

- [ ] :white_check_mark: Yes! - Issue number:
- [x] :x: No, sorry.

## Description

I noticed that the links for HOWTO - Contributors and HOWTO - Maintainers were getting a 404 response, so I changed the URL in the markdown and they seem to redirect correctly now. 